### PR TITLE
無駄なジェネレーター関数名を削除する

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
     "flow-vars",
   ],
   "rules": {
+    "func-names": 0,
     "no-console": 0,
     "no-underscore-dangle": 0,
     "flow-vars/define-flow-type": 1,

--- a/test/monads/Identity.spec.js
+++ b/test/monads/Identity.spec.js
@@ -43,7 +43,7 @@ describe('Identity', () => {
         .valueOf() === 3
       );
       assert(
-        doMonad(function* gen() {
+        doMonad(function*() {
           const value1 = yield new Identity(1);
           const value2 = yield new Identity(2);
           return new Identity(value1 + value2);


### PR DESCRIPTION
### やったこと
- [x] ESLintの`func-names`を無効にする
- [x] 無駄なジェネレーター関数名を削除する
